### PR TITLE
Update LaTeX headings detection

### DIFF
--- a/lib/abstract-model.js
+++ b/lib/abstract-model.js
@@ -59,61 +59,140 @@ export default class AbstractModel {
   }
 
   parseLevel(start, end, level) {
-    let headings = [];
-    let regex = this.HEADING_REGEX[level - 1]; // so we can give level 1 instead of level 0
-    // try {
-    this.buffer.scanInRange(regex, new Range(start, end), scanResult => {
-      let marker = this.headingMarkerLayer.markRange(scanResult.range, {invalidate: 'inside'});
-      let sectionStart = new Point(scanResult.range.start.row, 0);
-      let currentBlock = {
-        level: level,
-        marker: marker,
-        // this should be updated when we add the next result.
-        range: new Range(sectionStart, end),
+    let rawHeadings = [];
+    // let regex = this.HEADING_REGEX[level - 1]; // so we can give level 1 instead of level 0
+    let regex = this.HEADING_REGEX;
+
+    this.buffer.scanInRange(regex,  new Range(start, end), scanResult => {
+      // allow subclasses to customise how they get level, lable from regex
+      let res = this.getRegexData(scanResult);
+      let heading = {
+        level: res.level,
         headingRange: scanResult.range,
-        label: scanResult.match[2],
-        children: []
+        label: res.label,
+        children: [],
+        range: new Range(scanResult.range.start, Point.INFINITY)
       };
-
-      if (headings.length > 0) {
-        // update the previous heading block at this level if there is one
-        // set the end and parse its contents
-        let prevBlock = headings[headings.length - 1];
-        let sectionEnd = new Point(currentBlock.range.start.row - 1, 9999999);
-        prevBlock.range = new Range(prevBlock.range.start, sectionEnd);
-        // let sectionMarker = this.sectionMarkerLayer.markRange(prevBlock.range, {invalidate: 'inside'});
-
-        if (level <= this.maxDepth && level <= this.HEADING_REGEX.length) {
-          let subLevel = this.parseLevel(prevBlock.range.start,
-                                         prevBlock.range.end,
-                                         prevBlock.level + 1);
-          prevBlock.children = subLevel;
-          prevBlock.overwritten = 'yes';
-        }
-      } else if (level <= this.maxDepth && level <= this.HEADING_REGEX.length) {
-        // IF we are in the first block, will parse the whole thing.
-        // should be overwritten by next iteration :/
-        let subLevel = this.parseLevel(currentBlock.range.start,
-                                      end,
-                                      level + 1);
-        currentBlock.children = subLevel;
-      }
-
-      // TODO should only process the PREVIOUS one because otherwise the end will not be set
-      // however kinda need to process this one even if it means duplicating
-      // because not sure how to do last block otherwise
-      //  how to make sure the last block gets processed?
-      // maybe super inefficient, but for now could just process twice,
-      // once assuming till end which gets overridden in the next iter
-      // if (level <= this.maxDepth) {
-      //   let subLevel = this.parseLevel(currentBlock.start,
-      //                                    end,
-      //                                    currentBlock.level + 1);
-      //   currentBlock.children = subLevel;
-      // }
-
-      headings.push(currentBlock);
+      rawHeadings.push(heading);
     });
+
+    let stack = [{
+      level: 0,
+      label: '_hidden_root',
+      headingRange: new Range(Point.ZERO, Point.INFINITY),
+      children: [],
+      range: new Range(Point.ZERO, Point.INFINITY)
+    }];
+    // TODO might have to tweak the starst and ents...
+    let top;
+    for (let heading of rawHeadings) {
+      if (heading.level > this.maxDepth) {
+        continue;
+      }
+      top = stack.pop();
+      if (heading.level > top.level) {
+        top.children.push(heading);
+        stack.push(top);
+        stack.push(heading);
+      }
+      else if (heading.level === top.level) {
+        // At equal level, we close the previous heading
+        top.range.end = heading.headingRange.start;
+        // Then get the parent
+        top = stack.pop();
+        top.children.push(heading);
+        stack.push(top);
+        stack.push(heading);
+      } else if (top.level > heading.level) {
+        // This starts a new section at a more important level
+        // roll up the stack
+        top.range.end = heading.headingRange.start;
+        while (top) {
+          top = stack.pop();
+          // Close each range until we get to the suitable parent
+          top.range.end = heading.headingRange.start;
+          if (top.level < heading.level) {
+            break;
+          }
+        }
+        top.children.push(heading);
+        stack.push(top);
+        stack.push(heading);
+      }
+      //
+      // if (!prevHeading && heading.level > stack[stack.length - 1].level) {
+      //   stack[stack.length - 1].children.push(heading);
+      // } else if (heading.level <= this.maxDepth && heading.level === prevHeading.level) {
+      //   stack[stack.length - 1].children.push(heading);
+      // } else if (heading.level > prevHeading.level) {
+      //   // Drop down one level
+      //   stack.push(prevHeading); // might need to make sure we don't overwrite here...
+      //   prevHeading = null;
+      //   stack[stack.length - 1].children.push(heading);
+      // }
+      // else if (heading.level <= stack[stack.length - 1].level) {
+      //   let parent = stack[stack.length - 1];
+      //   while (heading.level <= parent.level) {
+      //     parent = stack.pop();
+      //   }
+      //   parent.children.push(heading);
+      // }
+      // prevHeading = heading;
+    }
+    //
+    // this.buffer.scanInRange(regex, new Range(start, end), scanResult => {
+    //   let marker = this.headingMarkerLayer.markRange(scanResult.range, {invalidate: 'inside'});
+    //   let sectionStart = new Point(scanResult.range.start.row, 0);
+    //   let currentBlock = {
+    //     level: level,
+    //     marker: marker,
+    //     // this should be updated when we add the next result.
+    //     range: new Range(sectionStart, end),
+    //     headingRange: scanResult.range,
+    //     label: scanResult.match[2],
+    //     children: []
+    //   };
+    //
+    //   if (headings.length > 0) {
+    //     // update the previous heading block at this level if there is one
+    //     // set the end and parse its contents
+    //     let prevBlock = headings[headings.length - 1];
+    //     let sectionEnd = new Point(currentBlock.range.start.row - 1, 9999999);
+    //     prevBlock.range = new Range(prevBlock.range.start, sectionEnd);
+    //     // let sectionMarker = this.sectionMarkerLayer.markRange(prevBlock.range, {invalidate: 'inside'});
+    //
+    //     if (level <= this.maxDepth && level <= this.HEADING_REGEX.length) {
+    //       let subLevel = this.parseLevel(prevBlock.range.start,
+    //                                      prevBlock.range.end,
+    //                                      prevBlock.level + 1);
+    //       prevBlock.children = subLevel;
+    //       prevBlock.overwritten = 'yes';
+    //     }
+    //   }
+    //   if (level <= this.maxDepth && level <= this.HEADING_REGEX.length) {
+    //     // IF we are in the first block, will parse the whole thing.
+    //     // should be overwritten by next iteration :/
+    //     let subLevel = this.parseLevel(currentBlock.range.start,
+    //                                   end,
+    //                                   level + 1);
+    //     currentBlock.children = subLevel;
+    //   }
+    //
+    //   // TODO should only process the PREVIOUS one because otherwise the end will not be set
+    //   // however kinda need to process this one even if it means duplicating
+    //   // because not sure how to do last block otherwise
+    //   //  how to make sure the last block gets processed?
+    //   // maybe super inefficient, but for now could just process twice,
+    //   // once assuming till end which gets overridden in the next iter
+    //   // if (level <= this.maxDepth) {
+    //   //   let subLevel = this.parseLevel(currentBlock.start,
+    //   //                                    end,
+    //   //                                    currentBlock.level + 1);
+    //   //   currentBlock.children = subLevel;
+    //   // }
+    //
+    //   headings.push(currentBlock);
+    // });
 
     // TODO would prefer it this way,but if we do it in callback should at least guarantee to be run with async...
     // for (var i = 1; i < headings.length; i++) {
@@ -121,27 +200,30 @@ export default class AbstractModel {
     //   let thisBlock = headings[i];
     //   prevBlock.end = thisBlock.start;
     // }
+    //
+    // if (level <= this.maxDepth) {
+    //   if (headings.length > 1) {
+    //     let lastBlock = headings[headings.length - 1];
+    //     let subLevel = this.parseLevel(lastBlock.range.start,
+    //                                    end,
+    //                                    lastBlock.level + 1);
+    //     lastBlock.children = subLevel;
+    //   }
+    // }
+    // TODO what happens if there ARE results for this level but there is
+    // a first header at a lower level:
+    // # Top
+    // ### Second
+    // ## Third
 
-    if (level <= this.maxDepth) {
-      if (headings.length > 1) {
-        let lastBlock = headings[headings.length - 1];
-        let subLevel = this.parseLevel(lastBlock.range.start,
-                                       end,
-                                       lastBlock.level + 1);
-        lastBlock.children = subLevel;
-      }
-    }
 
     // In case there are no results for this level, want to add an empty holder and try the next level down
-    if (headings.length === 0 && level <= this.maxDepth) {
-      headings = this.parseLevel(start, end, level + 1);
-    }
-    // } catch (error) {
-    //   this.emitter.emit('did-error', error);
-    //   return false;
+    // if (headings.length === 0 && level <= this.maxDepth) {
+    //   headings = this.parseLevel(start, end, level + 1);
     // }
 
-    return headings;
+    return stack[0].children;
+    // return headings;
   }
 
   recreateMarker(marker) {

--- a/lib/latex-model.js
+++ b/lib/latex-model.js
@@ -2,12 +2,15 @@
 import AbstractModel from './abstract-model';
 
 // could just generate these...
-const H1_REGEX = /(\\section){(.*)}/g;
-const H2_REGEX = /(\\subsection){(.*)}/g;
-const H3_REGEX = /(\\subsubsection){(.*)}/g;
-const H4_REGEX = /(\\subsubsubsection){(.*)}/g;
+const H1_REGEX = /^(\\part\*?){([^}]*)/g;
+const H2_REGEX = /^(\\chapter\*?){([^}]*)/g;
+const H3_REGEX = /^(\\section\*?){([^}]*)/g;
+const H4_REGEX = /^(\\subsection\*?){([^}]*)/g;
+const H5_REGEX = /^(\\subsubsection\*?){([^}]*)/g;
+const H6_REGEX = /^(\\paragraph\*?){([^}]*)/g;
+const H7_REGEX = /^(\\subparagraph\*?){([^}]*)/g;
 
-const HEADING_REGEX = [H1_REGEX, H2_REGEX, H3_REGEX, H4_REGEX];
+const HEADING_REGEX = [H1_REGEX, H2_REGEX, H3_REGEX, H4_REGEX, H5_REGEX, H6_REGEX, H7_REGEX];
 
 export default class LatexModel extends AbstractModel {
   constructor(editorOrBuffer) {

--- a/lib/latex-model.js
+++ b/lib/latex-model.js
@@ -1,7 +1,6 @@
 'use babel';
 import AbstractModel from './abstract-model';
 
-// could just generate these...
 const H1_REGEX = /^(\\part\*?){([^}]*)/g;
 const H2_REGEX = /^(\\chapter\*?){([^}]*)/g;
 const H3_REGEX = /^(\\section\*?){([^}]*)/g;
@@ -12,8 +11,16 @@ const H7_REGEX = /^(\\subparagraph\*?){([^}]*)/g;
 
 const HEADING_REGEX = [H1_REGEX, H2_REGEX, H3_REGEX, H4_REGEX, H5_REGEX, H6_REGEX, H7_REGEX];
 
+const HEADING_REGEX = /(\\((sub)*)section){(.*)}/g;
 export default class LatexModel extends AbstractModel {
   constructor(editorOrBuffer) {
     super(editorOrBuffer, HEADING_REGEX);
+  }
+
+  getRegexData(scanResult) {
+    return {
+      level: Math.floor(scanResult.match[2].length / 3),
+      label: scanResult.match[4]
+    };
   }
 }

--- a/lib/markdown-model.js
+++ b/lib/markdown-model.js
@@ -10,10 +10,19 @@ const H5_REGEX = /(^#####)[^#](.*)/g;
 const H6_REGEX = /(^######)[^#](.*)/g;
 const H7_REGEX = /(^######)[^#](.*)/g;
 
-const HEADING_REGEX = [H1_REGEX, H2_REGEX, H3_REGEX, H4_REGEX, H5_REGEX, H6_REGEX, H7_REGEX];
+// const HEADING_REGEX = [H1_REGEX, H2_REGEX, H3_REGEX, H4_REGEX, H5_REGEX, H6_REGEX, H7_REGEX];
+const HEADING_REGEX = /(^#+)[^#](.*)/g;
 
 export default class MarkdownModel extends AbstractModel {
   constructor(editorOrBuffer) {
     super(editorOrBuffer, HEADING_REGEX);
   }
+
+  getRegexData(scanResult) {
+    return {
+      level: scanResult.match[1].length,
+      label: scanResult.match[2]
+    };
+  }
+
 }

--- a/spec/longtext.md
+++ b/spec/longtext.md
@@ -109,6 +109,8 @@ pervenit, hic sensit, tellusAndros femineos miles feres fiat venis!
 
 # Imagine subiecta suppressit monte vulnera 13
 
+some texts
+
 ### Troiana lumine 14
 
 Lorem markdownum remorum flenti ius sed sanguine iussus doctior: o gratia
@@ -121,11 +123,20 @@ terris nimium. Sine deae in vel spem plangorem deus montes nova pares, non.
 - Demens consulit tantis quicquid constitit nemorum
 - Se sinus deceptus artus vitiataque oriuntur coronatis
 
+
+### Troiana lumine 14b
+
+Lorem markdownum remorum flenti ius sed sanguine iussus doctior: o gratia
+miratur sinunt volvuntur carmen cognoscenda. Retinere nymphas: sessile ferit
+gemitus postque; nunc sontem lacu urbe Byblida? Petit dent dubitat, nec castaque
+terris nimium. Sine deae in vel spem plangorem deus montes nova pares, non.
+**Dederat** subiit; sunt inque Flentibus humano huc bina, una ab sui.
+
 ## Congelat nataeque longius quoque plus capillis quae 15
 
 Hanc suis tela cupido sedens. Cytherea nam Esse simillimus rugosis.
 
-##### Non cunctari in forma 16
+#### Non cunctari in forma 16
 
 Descendunt perque pater media talia tereti saliunt ex direptos, tum illa
 concedant. [Antrum](http://www.videtviri.io/) et victam Teleboasque Dicta si
@@ -154,7 +165,7 @@ pervenit, hic sensit, tellusAndros femineos miles feres fiat venis!
 
 # Imagine subiecta suppressit monte vulnera 19
 
-## Troiana lumine
+## Troiana lumine 20
 
 Lorem markdownum remorum flenti ius sed sanguine iussus doctior: o gratia
 miratur sinunt volvuntur carmen cognoscenda. Retinere nymphas: sessile ferit
@@ -166,18 +177,18 @@ terris nimium. Sine deae in vel spem plangorem deus montes nova pares, non.
 - Demens consulit tantis quicquid constitit nemorum
 - Se sinus deceptus artus vitiataque oriuntur coronatis
 
-## Congelat nataeque longius quoque plus capillis quae
+## Congelat nataeque longius quoque plus capillis quae 21
 
 Hanc suis tela cupido sedens. Cytherea nam Esse simillimus rugosis.
 
-### Non cunctari in forma
+### Non cunctari in forma 22
 
 Descendunt perque pater media talia tereti saliunt ex direptos, tum illa
 concedant. [Antrum](http://www.videtviri.io/) et victam Teleboasque Dicta si
 tibi, lacertis carmina oceano lateque [dabitis meum](http://caret.com/), aquas
 annum quinque.
 
-## Nova colonus temeraria tulit sonum gratissime unda
+## Nova colonus temeraria tulit sonum gratissime unda 23
 
 Cum quem caelum, si curaque corpus dixit: quae *minari omnes* utraque secus est
 flumine. Orbem ministri auribus quod femina constitit urbes, rictus mihi, aut.
@@ -203,7 +214,7 @@ choro de peterem, dis tu aequora unde cervicem iam vidisti.
         on_overclocking_isp += ugc_intellectual_wildcard;
     }
 
-## In fronde iniceret et lacrimas terroris omnia
+## In fronde iniceret et lacrimas terroris omnia 24
 
 Paras Solis subito: vana liceatque *stante fixit* genibus accepit est ignisque
 suis delusum, non. Haberet traxit *si natus* viderat illa, meus fata attulerat


### PR DESCRIPTION
Few fixes to better analyse LaTeX document headings:
1. Updated document structure, according to [wiki](https://en.wikibooks.org/wiki/LaTeX/Document_Structure#Sectioning_commands)
2. Added detection of starred versions of headings.
3. Added rule for the "\XXX" part to be the first thing on a line --- previous version was not proof for, e.g., commenting out the line.
4. Added rule to save only the string of a heading name up to the first "}" sign --- previous version tend to expand the name if more commands were on the same line.